### PR TITLE
Note the default value of perf_event`paranoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ main = do
 
 Alternatively, run `echo 2 | sudo tee /proc/sys/kernel/perf_event_paranoid`.
 
+By default `perf_event_paranoid` is set to `2` since Linux 4.6 (and before that the default was `1`). Unless your distribution configures it differently you are fine.
+
 On CI systems under your control and many public CI services, there should be no barriers to root access so this should not be a showstopper to using this approach for performance regression tests.


### PR DESCRIPTION
While looking at [perf_event_open(2)] I noticed these defaults

             /proc/sys/kernel/perf_event_paranoid
                  The perf_event_paranoid file can be set to restrict access
                  to the performance counters.

                  2   allow only user-space measurements (default since
                      Linux 4.6).
                  1   allow both kernel and user measurements (default
                      before Linux 4.6).
                  0   allow access to CPU-specific data but not raw trace‐
                      point samples.
                  -1  no restrictions.

                  The existence of the perf_event_paranoid file is the offi‐
                  cial method for determining if a kernel supports
                  perf_event_open().

I thought it would be useful to mention them in README.

[perf_event_open(2)]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html